### PR TITLE
Embed Positions.v into the framework of TransitionSystem.v

### DIFF
--- a/Assigned/Positions.v
+++ b/Assigned/Positions.v
@@ -496,19 +496,16 @@ Module Make (Key Owner : DecidableTypeBoth) (Map : FMapInterface.WSfun Owner).
       end
     end.
 
-  Lemma generate_body_eq_try_fold :
+  Lemma try_fold_eq_generate_body :
     forall
     (x : list Card.t)
     (s : State.t),
-    Setoid.try_fold _ _
-      s
-      State.Signature.(Algebraic.f) x = Some
-        (generate_body x s).
+    Setoid.try_fold Label.t State.t s (Algebraic.f State.Signature) x =
+    Some (generate_body x s).
   Proof.
     induction x as [| u₀ x₀ IHx₀].
       reflexivity.
-    intros s.
-    simpl; now rewrite IHx₀.
+    intros s; simpl; now rewrite IHx₀.
   Qed.
 
   Definition generate
@@ -562,6 +559,6 @@ Module Make (Key Owner : DecidableTypeBoth) (Map : FMapInterface.WSfun Owner).
       (Some (generate_body cards State.initial_state))
       (Some t)).
       inversion_clear H as [? ? H'|]; apply H'.
-    now rewrite <- generate_body_eq_try_fold.
+    now rewrite <- try_fold_eq_generate_body.
   Qed.
 End Make.

--- a/Assigned/Positions.v
+++ b/Assigned/Positions.v
@@ -467,19 +467,13 @@ Module Make (Key Owner : DecidableTypeBoth) (Map : FMapInterface.WSfun Owner).
     split.
       apply Ok.initial_state.
     intros [k₀| p₀] x₀ s _ Ok_x₀_s.
-      exists (State.talon s); split.
-        simpl.
-        constructor.
-        now constructor.
+      exists (State.talon s); split; [reflexivity|].
       now apply Ok.talon.
-    destruct (Map.find p₀ s.(State.owner_to_indices)) as [indices|] eqn: e.
-      exists (State.assigned_mapsto s p₀ indices); split.
-        simpl; rewrite e.
-        now constructor.
+    simpl; destruct (Map.find p₀ s.(State.owner_to_indices))
+      as [indices|] eqn: find_p₀_s.
+      exists (State.assigned_mapsto s p₀ indices); split; [reflexivity|].
       now apply Ok.assigned_mapsto; [apply Map_Facts.find_mapsto_iff|].
-    exists (State.assigned_not_in s p₀); split.
-      simpl; rewrite e.
-      now constructor.
+    exists (State.assigned_not_in s p₀); split; [reflexivity|].
     now apply Ok.assigned_not_in; [apply Map_Facts.not_find_in_iff|].
   Qed.
 

--- a/Assigned/Positions.v
+++ b/Assigned/Positions.v
@@ -429,18 +429,10 @@ Module Make (Key Owner : DecidableTypeBoth) (Map : FMapInterface.WSfun Owner).
   Qed.
   Next Obligation.
     intros x x' x_eq_x' s s' (index_eq_index' & positions_eq_positions').
-    rewrite 2!Ok.Raw.
-    repeat try apply and_iff_morphism.
-          now rewrite x_eq_x', index_eq_index'.
-        apply all_iff_morphism; intros owner.
-        now rewrite x_eq_x', positions_eq_positions'.
-      apply all_iff_morphism; intros owner;
-      apply all_iff_morphism; intros indices.
-      now rewrite positions_eq_positions'.
-    apply all_iff_morphism; intros owner;
-    apply all_iff_morphism; intros indices;
-    apply all_iff_morphism; intros offset.
-    now rewrite x_eq_x', positions_eq_positions'.
+    now rewrite 2!Ok.Raw;
+    setoid_rewrite x_eq_x';
+    setoid_rewrite index_eq_index';
+    setoid_rewrite positions_eq_positions'.
   Qed.
 
   Instance Theory_L_S

--- a/Assigned/Positions.v
+++ b/Assigned/Positions.v
@@ -398,6 +398,16 @@ Module Make (Key Owner : DecidableTypeBoth) (Map : FMapInterface.WSfun Owner).
     apply y_eq_z.
   Qed.
 
+  Instance Morphism_new :
+    Proper (Logic.eq ==> Map.Equal ==> Setoid.eq) State.new.
+  Proof.
+    intros index index' index_eq_index'
+      positions positions' positions_eq_positions'; split.
+      now rewrite index_eq_index'.
+    simpl.
+    now rewrite positions_eq_positions'.
+  Qed.
+
   Instance Morphism_index :
     Proper (Setoid.eq ==> Logic.eq) State.index.
   Proof.
@@ -410,16 +420,6 @@ Module Make (Key Owner : DecidableTypeBoth) (Map : FMapInterface.WSfun Owner).
   Proof.
     intros s s' s_eq_s'.
     apply s_eq_s'.
-  Qed.
-
-  Instance Morphism_new :
-    Proper (Logic.eq ==> Map.Equal ==> Setoid.eq) State.new.
-  Proof.
-    intros index index' index_eq_index'
-      positions positions' positions_eq_positions'; split.
-      now rewrite index_eq_index'.
-    simpl.
-    now rewrite positions_eq_positions'.
   Qed.
 
   Unset Program Cases.

--- a/Assigned/Positions.v
+++ b/Assigned/Positions.v
@@ -129,6 +129,9 @@ Module Make (Key Owner : DecidableTypeBoth) (Map : FMapInterface.WSfun Owner).
     Instance Eq :
       Setoid.Eq t :=
       Card.eq.
+
+    Program Instance Setoid :
+      Setoid.Setoid t.
   End Label.
 
   Program Definition Signature_L :
@@ -425,8 +428,7 @@ Module Make (Key Owner : DecidableTypeBoth) (Map : FMapInterface.WSfun Owner).
 
   Unset Program Cases.
   #[program]
-  Instance Signature_L_S
-    {Setoid_L : TransitionSystem.Setoid.Setoid Label.t} :
+  Instance Signature_L_S :
     Algebraic.Signature Label.t State.t :=
     {|
       Algebraic.init :=
@@ -461,8 +463,7 @@ Module Make (Key Owner : DecidableTypeBoth) (Map : FMapInterface.WSfun Owner).
     setoid_rewrite positions_eq_positions'.
   Qed.
 
-  Instance Theory_L_S
-    {Setoid_L : TransitionSystem.Setoid.Setoid Label.t} :
+  Instance Theory_L_S :
     Algebraic.Theory Signature_L Signature_L_S.
   Proof.
     split.
@@ -495,8 +496,7 @@ Module Make (Key Owner : DecidableTypeBoth) (Map : FMapInterface.WSfun Owner).
       end
     end.
 
-  Lemma generate_body_eq_try_fold
-    {Setoid_L : Setoid.Setoid Label.t} :
+  Lemma generate_body_eq_try_fold :
     forall
     (x : list Card.t)
     (s : State.t),
@@ -521,9 +521,7 @@ Module Make (Key Owner : DecidableTypeBoth) (Map : FMapInterface.WSfun Owner).
   #[local]
   Hint Resolve Algebraic.to_Relational_Path_Theory : typeclass_instances.
 
-  Lemma generate_spec
-    {Setoid_L : Setoid.Setoid Label.t}
-    {Setoid_S : Setoid.Setoid State.t} :
+  Lemma generate_spec :
     forall
     cards : list Card.t,
     (forall

--- a/Assigned/Positions.v
+++ b/Assigned/Positions.v
@@ -477,9 +477,6 @@ Module Make (Key Owner : DecidableTypeBoth) (Map : FMapInterface.WSfun Owner).
     now apply Ok.assigned_not_in; [apply Map_Facts.not_find_in_iff|].
   Qed.
 
-  Notation Graph :=
-    (TransitionSystem.Relational.Path.R (Algebraic.to_Relational_Signature Signature_L_S)).
-
   Fixpoint generate_body
     (cards : list Card.t)
     (state : State.t) :

--- a/Assigned/Positions.v
+++ b/Assigned/Positions.v
@@ -4,9 +4,7 @@ Require Import
   Coq.Structures.Equalities
   Coq.Lists.List
   Coq.Lists.SetoidList
-  Coq.Sorting.Sorted
-  Coq.Classes.RelationClasses
-  Coq.Classes.Morphisms_Prop.
+  Coq.Sorting.Sorted.
 
 Import
   ListNotations.

--- a/Assigned/Positions.v
+++ b/Assigned/Positions.v
@@ -412,6 +412,16 @@ Module Make (Key Owner : DecidableTypeBoth) (Map : FMapInterface.WSfun Owner).
     apply s_eq_s'.
   Qed.
 
+  Instance Morphism_new :
+    Proper (Logic.eq ==> Map.Equal ==> Setoid.eq) State.new.
+  Proof.
+    intros index index' index_eq_index'
+      positions positions' positions_eq_positions'; split.
+      now rewrite index_eq_index'.
+    simpl.
+    now rewrite positions_eq_positions'.
+  Qed.
+
   Unset Program Cases.
   #[program]
   Instance Signature_L_S

--- a/Assigned/Positions.v
+++ b/Assigned/Positions.v
@@ -121,16 +121,18 @@ Module Make (Key Owner : DecidableTypeBoth) (Map : FMapInterface.WSfun Owner).
   Module EqA := List.FromEqListA Card.
   Module RNthA_Facts := List.RNthAFactsOn Card EqA RNthA.
 
-  Definition L :
-    Type :=
-    Card.t.
+  Module Label.
+    Definition t :
+      Type :=
+      Card.t.
 
-  Instance Eq_L :
-    Setoid.Eq L :=
-    Card.eq.
+    Instance Eq :
+      Setoid.Eq t :=
+      Card.eq.
+  End Label.
 
   Program Definition Signature_L :
-    Label.Signature L :=
+    Label.Signature Label.t :=
     {|
       Label.Ok x :=
         True;
@@ -424,8 +426,8 @@ Module Make (Key Owner : DecidableTypeBoth) (Map : FMapInterface.WSfun Owner).
   Unset Program Cases.
   #[program]
   Instance Signature_L_S
-    {Setoid_L : TransitionSystem.Setoid.Setoid L} :
-    Algebraic.Signature L State.t :=
+    {Setoid_L : TransitionSystem.Setoid.Setoid Label.t} :
+    Algebraic.Signature Label.t State.t :=
     {|
       Algebraic.init :=
         State.initial_state;
@@ -460,7 +462,7 @@ Module Make (Key Owner : DecidableTypeBoth) (Map : FMapInterface.WSfun Owner).
   Qed.
 
   Instance Theory_L_S
-    {Setoid_L : TransitionSystem.Setoid.Setoid L} :
+    {Setoid_L : TransitionSystem.Setoid.Setoid Label.t} :
     Algebraic.Theory Signature_L Signature_L_S.
   Proof.
     split.
@@ -494,7 +496,7 @@ Module Make (Key Owner : DecidableTypeBoth) (Map : FMapInterface.WSfun Owner).
     end.
 
   Lemma generate_body_eq_try_fold
-    {Setoid_L : Setoid.Setoid L} :
+    {Setoid_L : Setoid.Setoid Label.t} :
     forall
     (x : list Card.t)
     (s : State.t),
@@ -520,7 +522,7 @@ Module Make (Key Owner : DecidableTypeBoth) (Map : FMapInterface.WSfun Owner).
   Hint Resolve Algebraic.to_Relational_Path_Theory : typeclass_instances.
 
   Lemma generate_spec
-    {Setoid_L : Setoid.Setoid L}
+    {Setoid_L : Setoid.Setoid Label.t}
     {Setoid_S : Setoid.Setoid State.t} :
     forall
     cards : list Card.t,

--- a/Assigned/Positions.v
+++ b/Assigned/Positions.v
@@ -445,23 +445,12 @@ Module Make (Key Owner : DecidableTypeBoth) (Map : FMapInterface.WSfun Owner).
         Ok.t;
     |}.
   Next Obligation.
-    intros s s' s_eq_s' [k| p] [k'| p'] u_eq_u'; constructor.
-          change (Key.eq k k') in u_eq_u'; split.
-            simpl; f_equal.
-            apply s_eq_s'.
-          apply s_eq_s'.
-        inversion u_eq_u'.
-      inversion u_eq_u'.
-    destruct s_eq_s' as (index_eq_index' & positions_eq_positions').
-    change (Owner.eq p p') in u_eq_u'; simpl in *.
-    rewrite positions_eq_positions'.
-    destruct (Map.find p (State.owner_to_indices s')) as [indices'|] eqn: e; simpl in *;  rewrite u_eq_u' in e; rewrite e; simpl.
-      split; simpl.
-        now f_equal.
-      now rewrite u_eq_u', index_eq_index', positions_eq_positions'.
-    split; simpl.
-      now f_equal.
-    now rewrite u_eq_u', index_eq_index', positions_eq_positions'.
+    intros s s' s_eq_s' [k| p] [k'| p'] u_eq_u';
+    compute in u_eq_u'; try contradiction; constructor.
+      now rewrite s_eq_s'.
+    rewrite u_eq_u', s_eq_s'.
+    destruct (Map.find p' (State.owner_to_indices s')) as [indices'|];
+    now rewrite u_eq_u', s_eq_s'.
   Qed.
   Next Obligation.
     intros x x' x_eq_x' s s' (index_eq_index' & positions_eq_positions').

--- a/Assigned/Positions.v
+++ b/Assigned/Positions.v
@@ -398,6 +398,13 @@ Module Make (Key Owner : DecidableTypeBoth) (Map : FMapInterface.WSfun Owner).
     apply y_eq_z.
   Qed.
 
+  Instance Morphism_index :
+    Proper (Setoid.eq ==> Logic.eq) State.index.
+  Proof.
+    intros s s' s_eq_s'.
+    apply s_eq_s'.
+  Qed.
+
   Unset Program Cases.
   #[program]
   Instance Signature_L_S

--- a/Assigned/Positions.v
+++ b/Assigned/Positions.v
@@ -248,183 +248,183 @@ Module Make (Key Owner : DecidableTypeBoth) (Map : FMapInterface.WSfun Owner).
           [s.(index)]
           s.(owner_to_indices);
       |}.
-  End State.
 
-  Module Ok.
-    Record t
-      (x : list Card.t)
-      (s : State.t) :
-      Prop :=
-      new {
-        length :
-          s.(State.index) = length x;
-        contains :
-          forall
-          owner : Owner.t,
-          State.Contains s owner <->
-          InA Card.eq (Card.Assigned owner) x;
-        sorted :
-          forall
-          (owner : Owner.t)
-          (indices : list nat),
-          State.MapsTo s owner indices ->
-          LocallySorted Peano.gt indices;
-        positions :
-          forall
-          (owner : Owner.t)
-          (indices : list nat)
-          (offset : nat),
-          State.MapsTo s owner indices ->
-          In offset indices <->
-          RNthA.t (Card.Assigned owner) x offset;
-      }.
+    Module Ok.
+      Record t
+        (x : list Card.t)
+        (s : State.t) :
+        Prop :=
+        new {
+          length :
+            s.(State.index) = length x;
+          contains :
+            forall
+            owner : Owner.t,
+            State.Contains s owner <->
+            InA Card.eq (Card.Assigned owner) x;
+          sorted :
+            forall
+            (owner : Owner.t)
+            (indices : list nat),
+            State.MapsTo s owner indices ->
+            LocallySorted Peano.gt indices;
+          positions :
+            forall
+            (owner : Owner.t)
+            (indices : list nat)
+            (offset : nat),
+            State.MapsTo s owner indices ->
+            In offset indices <->
+            RNthA.t (Card.Assigned owner) x offset;
+        }.
 
-    Lemma Raw :
-      forall
-      (x : list Card.t)
-      (s : State.t),
-      t x s <->
-      s.(State.index) = List.length x /\
-      (forall
-      owner : Owner.t,
-      State.Contains s owner <->
-      InA Card.eq (Card.Assigned owner) x) /\
-      (forall
-      (owner : Owner.t)
-      (indices : list nat),
-      State.MapsTo s owner indices ->
-      LocallySorted Peano.gt indices) /\
-      (forall
-      (owner : Owner.t)
-      (indices : list nat)
-      (offset : nat),
-      State.MapsTo s owner indices ->
-      In offset indices <->
-      RNthA.t (Card.Assigned owner) x offset).
-    Proof.
-      intros x s; split.
-        now intros [length_x contains_s sorted_s positions_s].
-      intros (length_x & contains_s & sorted_s & positions_s).
-      now constructor.
-    Qed.
+      Lemma Raw :
+        forall
+        (x : list Card.t)
+        (s : State.t),
+        t x s <->
+        s.(State.index) = List.length x /\
+        (forall
+        owner : Owner.t,
+        State.Contains s owner <->
+        InA Card.eq (Card.Assigned owner) x) /\
+        (forall
+        (owner : Owner.t)
+        (indices : list nat),
+        State.MapsTo s owner indices ->
+        LocallySorted Peano.gt indices) /\
+        (forall
+        (owner : Owner.t)
+        (indices : list nat)
+        (offset : nat),
+        State.MapsTo s owner indices ->
+        In offset indices <->
+        RNthA.t (Card.Assigned owner) x offset).
+      Proof.
+        intros x s; split.
+          now intros [length_x contains_s sorted_s positions_s].
+        intros (length_x & contains_s & sorted_s & positions_s).
+        now constructor.
+      Qed.
 
-    Lemma initial_state :
-      t [] State.initial_state.
-    Proof.
-      constructor; simpl.
-            reflexivity.
-          now intros owner; rewrite Map_Facts.empty_in_iff, InA_nil.
-        intros owner indices owner_to_indices.
+      Lemma initial_state :
+        t [] State.initial_state.
+      Proof.
+        constructor; simpl.
+              reflexivity.
+            now intros owner; rewrite Map_Facts.empty_in_iff, InA_nil.
+          intros owner indices owner_to_indices.
+          now apply Map_Facts.empty_mapsto_iff in owner_to_indices.
+        intros owner indices subtrahend owner_to_indices.
         now apply Map_Facts.empty_mapsto_iff in owner_to_indices.
-      intros owner indices subtrahend owner_to_indices.
-      now apply Map_Facts.empty_mapsto_iff in owner_to_indices.
-    Qed.
+      Qed.
 
-    Lemma cons_iff :
-      forall
-      (v u₀ : Card.t)
-      (x₀ : list Card.t)
-      (n : nat),
-      RNthA.t v (u₀ :: x₀) n <->
-      n = Datatypes.length x₀ /\ Card.eq v u₀ \/
-      RNthA.t v x₀ n.
-    Proof.
-      intros v u₀ x₀ n.
-      enough (RNthA.t v x₀ n -> n <> Datatypes.length x₀)
-        by (rewrite RNthA_Facts.cons_iff; tauto).
-      intros n_to_v.
-      now apply PeanoNat.Nat.lt_neq, RNthA_Facts.lt_iff; exists v.
-    Qed.
+      Lemma cons_iff :
+        forall
+        (v u₀ : Card.t)
+        (x₀ : list Card.t)
+        (n : nat),
+        RNthA.t v (u₀ :: x₀) n <->
+        n = Datatypes.length x₀ /\ Card.eq v u₀ \/
+        RNthA.t v x₀ n.
+      Proof.
+        intros v u₀ x₀ n.
+        enough (RNthA.t v x₀ n -> n <> Datatypes.length x₀)
+          by (rewrite RNthA_Facts.cons_iff; tauto).
+        intros n_to_v.
+        now apply PeanoNat.Nat.lt_neq, RNthA_Facts.lt_iff; exists v.
+      Qed.
 
-    Lemma talon :
-      forall
-      (x₀ : list Card.t)
-      (s₁ : State.t)
-      (key : Key.t),
-      t x₀ s₁ ->
-      t (Card.Talon key :: x₀) (State.talon s₁).
-    Proof.
-      intros x₀ (index & owner_to_indices) key Ok_s₁.
-      constructor.
-            apply eq_S, Ok_s₁.(length).
-          intros owner.
-          rewrite Ok_s₁.(contains), InA_cons; simpl; tauto.
-        intros owner indices owner_to_indices'.
-        now apply Ok_s₁.(sorted) with owner.
-      intros owner indices offset MapsTo_owner_indices.
-      rewrite cons_iff, Ok_s₁.(positions) with (1 := MapsTo_owner_indices); simpl; tauto.
-    Defined.
+      Lemma talon :
+        forall
+        (x₀ : list Card.t)
+        (s₁ : State.t)
+        (key : Key.t),
+        t x₀ s₁ ->
+        t (Card.Talon key :: x₀) (State.talon s₁).
+      Proof.
+        intros x₀ (index & owner_to_indices) key Ok_s₁.
+        constructor.
+              apply eq_S, Ok_s₁.(length).
+            intros owner.
+            rewrite Ok_s₁.(contains), InA_cons; simpl; tauto.
+          intros owner indices owner_to_indices'.
+          now apply Ok_s₁.(sorted) with owner.
+        intros owner indices offset MapsTo_owner_indices.
+        rewrite cons_iff, Ok_s₁.(positions) with (1 := MapsTo_owner_indices); simpl; tauto.
+      Defined.
 
-    Lemma assigned_mapsto :
-      forall
-      (p₀ : Owner.t)
-      (x₀ : list Card.t)
-      (s₁ : State.t)
-      (indices₀ : list nat),
-      State.MapsTo s₁ p₀ indices₀ ->
-      t x₀ s₁ ->
-      t (Card.Assigned p₀ :: x₀) (State.assigned_mapsto s₁ p₀ indices₀).
-    Proof with (simpl; firstorder).
-      intros p₀ x₀ (index & owner_to_indices) indices₀ MapsTo_p₀_indices₀ Ok_s₁.
-      constructor.
-            apply eq_S, Ok_s₁.(length).
-          intros owner; simpl.
-          rewrite Map_Facts.add_in_iff, Ok_s₁.(contains), InA_cons...
-        intros owner indices MapsTo_owner_indices.
+      Lemma assigned_mapsto :
+        forall
+        (p₀ : Owner.t)
+        (x₀ : list Card.t)
+        (s₁ : State.t)
+        (indices₀ : list nat),
+        State.MapsTo s₁ p₀ indices₀ ->
+        t x₀ s₁ ->
+        t (Card.Assigned p₀ :: x₀) (State.assigned_mapsto s₁ p₀ indices₀).
+      Proof with (simpl; firstorder).
+        intros p₀ x₀ (index & owner_to_indices) indices₀ MapsTo_p₀_indices₀ Ok_s₁.
+        constructor.
+              apply eq_S, Ok_s₁.(length).
+            intros owner; simpl.
+            rewrite Map_Facts.add_in_iff, Ok_s₁.(contains), InA_cons...
+          intros owner indices MapsTo_owner_indices.
+          apply Map_Facts.add_mapsto_iff in MapsTo_owner_indices as [
+            (_ & <-)|
+          (_ & MapsTo_owner_indices)].
+            destruct indices₀ as [| index₀ indices₀]; constructor.
+              now apply Ok_s₁.(sorted) with p₀.
+            rewrite Ok_s₁.(length).
+            apply RNthA_Facts.lt_iff; exists (Card.Assigned p₀).
+            now apply Ok_s₁.(positions) with (1 := MapsTo_p₀_indices₀); left.
+          now apply Ok_s₁.(sorted) with owner.
+        intros owner indices offset MapsTo_owner_indices;
+        rewrite cons_iff.
         apply Map_Facts.add_mapsto_iff in MapsTo_owner_indices as [
-          (_ & <-)|
-        (_ & MapsTo_owner_indices)].
-          destruct indices₀ as [| index₀ indices₀]; constructor.
-            now apply Ok_s₁.(sorted) with p₀.
-          rewrite Ok_s₁.(length).
-          apply RNthA_Facts.lt_iff; exists (Card.Assigned p₀).
-          now apply Ok_s₁.(positions) with (1 := MapsTo_p₀_indices₀); left.
-        now apply Ok_s₁.(sorted) with owner.
-      intros owner indices offset MapsTo_owner_indices;
-      rewrite cons_iff.
-      apply Map_Facts.add_mapsto_iff in MapsTo_owner_indices as [
-        (<- & <-)|
-      (p₀_neq_owner & MapsTo_owner_indices)].
-        simpl; rewrite Ok_s₁.(positions) with (1 := MapsTo_p₀_indices₀).
-        setoid_rewrite <- Ok_s₁.(length)...
-      setoid_replace (Owner.eq owner p₀) with (Owner.eq p₀ owner) by firstorder.
-      rewrite Ok_s₁.(positions) with (1 := MapsTo_owner_indices); tauto.
-    Qed.
+          (<- & <-)|
+        (p₀_neq_owner & MapsTo_owner_indices)].
+          simpl; rewrite Ok_s₁.(positions) with (1 := MapsTo_p₀_indices₀).
+          setoid_rewrite <- Ok_s₁.(length)...
+        setoid_replace (Owner.eq owner p₀) with (Owner.eq p₀ owner) by firstorder.
+        rewrite Ok_s₁.(positions) with (1 := MapsTo_owner_indices); tauto.
+      Qed.
 
-    Lemma assigned_not_in :
-      forall
-      (p₀ : Owner.t)
-      (x₀ : list Card.t)
-      (s₁ : State.t),
-      ~ Map.In p₀ s₁.(State.owner_to_indices) ->
-      t x₀ s₁ ->
-      t (Card.Assigned p₀ :: x₀) (State.assigned_not_in s₁ p₀).
-    Proof with (simpl; firstorder).
-      intros p₀ x₀ (index & owner_to_indices) not_In_p₀ Ok_s₁.
-      constructor.
-            apply eq_S, Ok_s₁.(length).
-          intros owner; simpl.
-          rewrite Map_Facts.add_in_iff, Ok_s₁.(contains), InA_cons...
-        intros owner indices MapsTo_owner_indices.
+      Lemma assigned_not_in :
+        forall
+        (p₀ : Owner.t)
+        (x₀ : list Card.t)
+        (s₁ : State.t),
+        ~ Map.In p₀ s₁.(State.owner_to_indices) ->
+        t x₀ s₁ ->
+        t (Card.Assigned p₀ :: x₀) (State.assigned_not_in s₁ p₀).
+      Proof with (simpl; firstorder).
+        intros p₀ x₀ (index & owner_to_indices) not_In_p₀ Ok_s₁.
+        constructor.
+              apply eq_S, Ok_s₁.(length).
+            intros owner; simpl.
+            rewrite Map_Facts.add_in_iff, Ok_s₁.(contains), InA_cons...
+          intros owner indices MapsTo_owner_indices.
+          apply Map_Facts.add_mapsto_iff in MapsTo_owner_indices as [
+            (_ & <-)|
+          (_ & MapsTo_owner_indices)].
+            constructor.
+          now apply Ok_s₁.(sorted) with owner.
+        intros owner indices offset MapsTo_owner_indices;
+        rewrite cons_iff.
         apply Map_Facts.add_mapsto_iff in MapsTo_owner_indices as [
-          (_ & <-)|
-        (_ & MapsTo_owner_indices)].
-          constructor.
-        now apply Ok_s₁.(sorted) with owner.
-      intros owner indices offset MapsTo_owner_indices;
-      rewrite cons_iff.
-      apply Map_Facts.add_mapsto_iff in MapsTo_owner_indices as [
-        (p₀_eq_owner & <-)|
-      (p₀_neq_owner & MapsTo_owner_indices)].
-        setoid_rewrite <- Ok_s₁.(length); simpl.
-        enough (~ RNthA.t (Card.Assigned owner) x₀ offset) by firstorder.
-        contradict not_In_p₀.
-        apply Ok_s₁.(contains),  RNthA_Facts.InA_iff.
-        now exists offset; rewrite p₀_eq_owner.
-      setoid_replace (Owner.eq owner p₀) with (Owner.eq p₀ owner) by firstorder.
-      rewrite <- Ok_s₁.(positions) with (1 := MapsTo_owner_indices); tauto.
-    Qed.
-  End Ok.
+          (p₀_eq_owner & <-)|
+        (p₀_neq_owner & MapsTo_owner_indices)].
+          setoid_rewrite <- Ok_s₁.(length); simpl.
+          enough (~ RNthA.t (Card.Assigned owner) x₀ offset) by firstorder.
+          contradict not_In_p₀.
+          apply Ok_s₁.(contains),  RNthA_Facts.InA_iff.
+          now exists offset; rewrite p₀_eq_owner.
+        setoid_replace (Owner.eq owner p₀) with (Owner.eq p₀ owner) by firstorder.
+        rewrite <- Ok_s₁.(positions) with (1 := MapsTo_owner_indices); tauto.
+      Qed.
+    End Ok.
+  End State.
 
   Unset Program Cases.
   #[program]
@@ -445,7 +445,7 @@ Module Make (Key Owner : DecidableTypeBoth) (Map : FMapInterface.WSfun Owner).
               end
           end);
       Algebraic.Ok :=
-        Ok.t;
+        State.Ok.t;
     |}.
   Next Obligation.
     intros s s' s_eq_s' [k| p] [k'| p'] u_eq_u';
@@ -457,7 +457,7 @@ Module Make (Key Owner : DecidableTypeBoth) (Map : FMapInterface.WSfun Owner).
   Qed.
   Next Obligation.
     intros x x' x_eq_x' s s' (index_eq_index' & positions_eq_positions').
-    now rewrite 2!Ok.Raw;
+    now rewrite 2!State.Ok.Raw;
     setoid_rewrite x_eq_x';
     setoid_rewrite index_eq_index';
     setoid_rewrite positions_eq_positions'.
@@ -467,16 +467,16 @@ Module Make (Key Owner : DecidableTypeBoth) (Map : FMapInterface.WSfun Owner).
     Algebraic.Theory Label.Signature Signature_L_S.
   Proof.
     split.
-      apply Ok.initial_state.
+      apply State.Ok.initial_state.
     intros [k₀| p₀] x₀ s _ Ok_x₀_s.
       exists (State.talon s); split; [reflexivity|].
-      now apply Ok.talon.
+      now apply State.Ok.talon.
     simpl; destruct (Map.find p₀ s.(State.owner_to_indices))
       as [indices|] eqn: find_p₀_s.
       exists (State.assigned_mapsto s p₀ indices); split; [reflexivity|].
-      now apply Ok.assigned_mapsto; [apply Map_Facts.find_mapsto_iff|].
+      now apply State.Ok.assigned_mapsto; [apply Map_Facts.find_mapsto_iff|].
     exists (State.assigned_not_in s p₀); split; [reflexivity|].
-    now apply Ok.assigned_not_in; [apply Map_Facts.not_find_in_iff|].
+    now apply State.Ok.assigned_not_in; [apply Map_Facts.not_find_in_iff|].
   Qed.
 
   Fixpoint generate_body
@@ -555,9 +555,9 @@ Module Make (Key Owner : DecidableTypeBoth) (Map : FMapInterface.WSfun Owner).
       split.
         apply Ok_cards_t.
       intros owner indices owner_to_indices; split.
-        now apply Ok_cards_t.(Ok.sorted) with owner.
+        now apply Ok_cards_t.(State.Ok.sorted) with owner.
       intros offset.
-      now apply Ok_cards_t.(Ok.positions).
+      now apply Ok_cards_t.(State.Ok.positions).
     enough (H : Setoid.eq
       (Some (generate_body cards State.initial_state))
       (Some t)).

--- a/Assigned/Positions.v
+++ b/Assigned/Positions.v
@@ -132,20 +132,20 @@ Module Make (Key Owner : DecidableTypeBoth) (Map : FMapInterface.WSfun Owner).
 
     Program Instance Setoid :
       Setoid.Setoid t.
+
+    Program Definition Signature :
+      Label.Signature Label.t :=
+      {|
+        Label.Ok x :=
+          True;
+      |}.
+    Next Obligation.
+      intros x x' x_eq_x'; reflexivity.
+    Qed.
+
+    Program Instance Theory :
+      Label.Theory Signature.
   End Label.
-
-  Program Definition Signature_L :
-    Label.Signature Label.t :=
-    {|
-      Label.Ok x :=
-        True;
-    |}.
-  Next Obligation.
-    intros x x' x_eq_x'; reflexivity.
-  Qed.
-
-  Program Instance Label_Theory_L :
-    Label.Theory Signature_L.
 
   Module State.
     Record t :
@@ -464,7 +464,7 @@ Module Make (Key Owner : DecidableTypeBoth) (Map : FMapInterface.WSfun Owner).
   Qed.
 
   Instance Theory_L_S :
-    Algebraic.Theory Signature_L Signature_L_S.
+    Algebraic.Theory Label.Signature Signature_L_S.
   Proof.
     split.
       apply Ok.initial_state.
@@ -544,7 +544,7 @@ Module Make (Key Owner : DecidableTypeBoth) (Map : FMapInterface.WSfun Owner).
     pose (Relational_Path_Signature_L_S :=
       Algebraic.to_Relational_Path_Signature Signature_L_S).
     specialize (Relational.Path.executable_Initial
-      Signature_L
+      Label.Signature
       Relational_Signature_L_S
       Relational_Path_Signature_L_S
       cards

--- a/Assigned/Positions.v
+++ b/Assigned/Positions.v
@@ -405,6 +405,13 @@ Module Make (Key Owner : DecidableTypeBoth) (Map : FMapInterface.WSfun Owner).
     apply s_eq_s'.
   Qed.
 
+  Instance Morphism_owner_to_indices :
+    Proper (Setoid.eq ==> Map.Equal) State.owner_to_indices.
+  Proof.
+    intros s s' s_eq_s'.
+    apply s_eq_s'.
+  Qed.
+
   Unset Program Cases.
   #[program]
   Instance Signature_L_S

--- a/Assigned/Positions.v
+++ b/Assigned/Positions.v
@@ -428,7 +428,7 @@ Module Make (Key Owner : DecidableTypeBoth) (Map : FMapInterface.WSfun Owner).
 
   Unset Program Cases.
   #[program]
-  Instance Signature_L_S :
+  Definition Signature_L_S :
     Algebraic.Signature Label.t State.t :=
     {|
       Algebraic.init :=

--- a/Assigned/Positions.v
+++ b/Assigned/Positions.v
@@ -383,6 +383,21 @@ Module Make (Key Owner : DecidableTypeBoth) (Map : FMapInterface.WSfun Owner).
       s.(State.index) = s'.(State.index) /\
       Map.Equal s.(State.owner_to_indices) s'.(State.owner_to_indices).
 
+  Instance Setoid_State :
+    Setoid.Setoid State.t.
+  Proof.
+    split.
+        intros x; split; reflexivity.
+      intros x y x_eq_y; split; symmetry; apply x_eq_y.
+    intros x y z x_eq_y y_eq_z; split.
+      transitivity (y.(State.index)).
+        apply x_eq_y.
+      apply y_eq_z.
+    transitivity (y.(State.owner_to_indices)).
+      apply x_eq_y.
+    apply y_eq_z.
+  Qed.
+
   Unset Program Cases.
   #[program]
   Instance Signature_L_S

--- a/Assigned/Positions.v
+++ b/Assigned/Positions.v
@@ -540,19 +540,29 @@ Module Make (Key Owner : DecidableTypeBoth) (Map : FMapInterface.WSfun Owner).
     RNthA.t (Card.Assigned owner) cards offset)).
   Proof.
     intros cards.
-    specialize (Relational.Path.executable_Initial Signature_L (Algebraic.to_Relational_Signature Signature_L_S) (Algebraic.to_Relational_Path_Signature Signature_L_S) cards State.initial_state I) as (t & Path_init_t & Ok_cards_t).
+    pose (Relational_Signature_L_S :=
+      Algebraic.to_Relational_Signature Signature_L_S).
+    pose (Relational_Path_Signature_L_S :=
+      Algebraic.to_Relational_Path_Signature Signature_L_S).
+    specialize (Relational.Path.executable_Initial
+      Signature_L
+      Relational_Signature_L_S
+      Relational_Path_Signature_L_S
+      cards
+      State.initial_state) as (t & Path_init_t & Ok_cards_t).
+        constructor.
       simpl; reflexivity.
-    change (Setoid.eq (Setoid.try_fold _ _ Signature_L_S.(Algebraic.init) Signature_L_S.(Algebraic.f) cards) (Some t)) in Path_init_t.
-    rewrite generate_body_eq_try_fold in Path_init_t.
-     change (generate cards) with ((generate_body cards State.initial_state).(State.owner_to_indices)).
-    inversion_clear Path_init_t.
-    destruct H as (index_eq_index' & positions_eq_positions').
-    setoid_rewrite positions_eq_positions'.
-    split.
-    apply Ok_cards_t.(Ok.contains).
-  intros owner indices owner_to_indices; split.
-    now apply Ok_cards_t.(Ok.sorted) with owner.
-  intros offset.
-  now apply Ok_cards_t.(Ok.positions).
+    setoid_replace (generate cards) with t.(State.owner_to_indices).
+      split.
+        apply Ok_cards_t.
+      intros owner indices owner_to_indices; split.
+        now apply Ok_cards_t.(Ok.sorted) with owner.
+      intros offset.
+      now apply Ok_cards_t.(Ok.positions).
+    enough (H : Setoid.eq
+      (Some (generate_body cards State.initial_state))
+      (Some t)).
+      inversion_clear H as [? ? H'|]; apply H'.
+    now rewrite <- generate_body_eq_try_fold.
   Qed.
 End Make.

--- a/Assigned/Positions.v
+++ b/Assigned/Positions.v
@@ -392,17 +392,16 @@ Module Make (Key Owner : DecidableTypeBoth) (Map : FMapInterface.WSfun Owner).
       Algebraic.init :=
         State.initial_state;
       Algebraic.f s u :=
-        match u with
-        | Card.Talon _ =>
-          Some (
-          State.talon s)
-        | Card.Assigned owner =>
-          Some (
-          match Map.find owner s.(State.owner_to_indices) with
-          | Some indices => State.assigned_mapsto s owner indices
-          | None => State.assigned_not_in s owner
-          end)
-        end;
+        Some
+          (match u with
+          | Card.Talon _ =>
+              State.talon s
+          | Card.Assigned owner =>
+              match Map.find owner s.(State.owner_to_indices) with
+              | Some indices => State.assigned_mapsto s owner indices
+              | None => State.assigned_not_in s owner
+              end
+          end);
       Algebraic.Ok :=
         Ok.t;
     |}.
@@ -489,8 +488,7 @@ Module Make (Key Owner : DecidableTypeBoth) (Map : FMapInterface.WSfun Owner).
     induction x as [| u₀ x₀ IHx₀].
       reflexivity.
     intros s.
-    simpl; rewrite IHx₀.
-    now destruct u₀.
+    simpl; now rewrite IHx₀.
   Qed.
 
   Definition generate

--- a/Assigned/Positions.v
+++ b/Assigned/Positions.v
@@ -525,32 +525,30 @@ Module Make (Key Owner : DecidableTypeBoth) (Map : FMapInterface.WSfun Owner).
     {Setoid_S : Setoid.Setoid State.t} :
     forall
     cards : list Card.t,
-    let positions := generate cards in
     (forall
-      owner : Owner.t,
-      InA Card.eq (Card.Assigned owner) cards <->
-      Map.In owner positions) /\
+    owner : Owner.t,
+    Map.In owner (generate cards) <->
+    InA Card.eq (Card.Assigned owner) cards) /\
     (forall
     (owner : Owner.t)
     (indices : list nat),
-    Map.MapsTo owner indices positions ->
+    Map.MapsTo owner indices (generate cards) ->
     LocallySorted Peano.gt indices /\
     (forall
     offset : nat,
     In offset indices <->
     RNthA.t (Card.Assigned owner) cards offset)).
   Proof.
-    intros cards positions.
+    intros cards.
     specialize (Relational.Path.executable_Initial Signature_L (Algebraic.to_Relational_Signature Signature_L_S) (Algebraic.to_Relational_Path_Signature Signature_L_S) cards State.initial_state I) as (t & Path_init_t & Ok_cards_t).
       simpl; reflexivity.
     change (Setoid.eq (Setoid.try_fold _ _ Signature_L_S.(Algebraic.init) Signature_L_S.(Algebraic.f) cards) (Some t)) in Path_init_t.
     rewrite generate_body_eq_try_fold in Path_init_t.
-     change positions with ((generate_body cards State.initial_state).(State.owner_to_indices)).
+     change (generate cards) with ((generate_body cards State.initial_state).(State.owner_to_indices)).
     inversion_clear Path_init_t.
     destruct H as (index_eq_index' & positions_eq_positions').
     setoid_rewrite positions_eq_positions'.
     split.
-    symmetry.
     apply Ok_cards_t.(Ok.contains).
   intros owner indices owner_to_indices; split.
     now apply Ok_cards_t.(Ok.sorted) with owner.

--- a/Assigned/Positions.v
+++ b/Assigned/Positions.v
@@ -385,7 +385,9 @@ Module Make (Key Owner : DecidableTypeBoth) (Map : FMapInterface.WSfun Owner).
       s.(State.index) = s'.(State.index) /\
       Map.Equal s.(State.owner_to_indices) s'.(State.owner_to_indices).
 
-  Program Instance Signature_L_S
+  Unset Program Cases.
+  #[program]
+  Instance Signature_L_S
     {Setoid_L : TransitionSystem.Setoid.Setoid L} :
     Algebraic.Signature L State.t :=
     {|
@@ -497,13 +499,8 @@ Module Make (Key Owner : DecidableTypeBoth) (Map : FMapInterface.WSfun Owner).
     induction x as [| u₀ x₀ IHx₀].
       reflexivity.
     intros s.
-    simpl.
-    rewrite IHx₀.
-    simpl.
-    destruct u₀; try reflexivity.
-    destruct ( Map.find t (State.owner_to_indices (generate_body x₀ s))).
-    reflexivity.
-    reflexivity.
+    simpl; rewrite IHx₀.
+    now destruct u₀.
   Qed.
 
   Definition generate

--- a/Assigned/Positions.v
+++ b/Assigned/Positions.v
@@ -150,6 +150,50 @@ Module Make (Key Owner : DecidableTypeBoth) (Map : FMapInterface.WSfun Owner).
         owner_to_indices : Map.t (list nat);
       }.
 
+    Instance Eq :
+      Setoid.Eq State.t :=
+      fun s s' : State.t =>
+        s.(State.index) = s'.(State.index) /\
+        Map.Equal s.(State.owner_to_indices) s'.(State.owner_to_indices).
+
+    Instance Setoid :
+      Setoid.Setoid State.t.
+    Proof.
+      split.
+          intros x; split; reflexivity.
+        intros x y x_eq_y; split; symmetry; apply x_eq_y.
+      intros x y z x_eq_y y_eq_z; split.
+        transitivity (y.(State.index)).
+          apply x_eq_y.
+        apply y_eq_z.
+      transitivity (y.(State.owner_to_indices)).
+        apply x_eq_y.
+      apply y_eq_z.
+    Qed.
+
+    Instance Morphism_new :
+      Proper (Logic.eq ==> Map.Equal ==> Setoid.eq) State.new.
+    Proof.
+      intros index index' index_eq_index'
+        positions positions' positions_eq_positions'; split.
+        now rewrite index_eq_index'.
+      simpl; now rewrite positions_eq_positions'.
+    Qed.
+
+    Instance Morphism_index :
+      Proper (Setoid.eq ==> Logic.eq) State.index.
+    Proof.
+      intros s s' s_eq_s'.
+      apply s_eq_s'.
+    Qed.
+
+    Instance Morphism_owner_to_indices :
+      Proper (Setoid.eq ==> Map.Equal) State.owner_to_indices.
+    Proof.
+      intros s s' s_eq_s'.
+      apply s_eq_s'.
+    Qed.
+
     Notation MapsTo
       s
       owner
@@ -376,51 +420,6 @@ Module Make (Key Owner : DecidableTypeBoth) (Map : FMapInterface.WSfun Owner).
       rewrite <- Ok_s₁.(positions) with (1 := MapsTo_owner_indices); tauto.
     Qed.
   End Ok.
-
-  Instance Eq_State :
-    Setoid.Eq State.t :=
-    fun s s' : State.t =>
-      s.(State.index) = s'.(State.index) /\
-      Map.Equal s.(State.owner_to_indices) s'.(State.owner_to_indices).
-
-  Instance Setoid_State :
-    Setoid.Setoid State.t.
-  Proof.
-    split.
-        intros x; split; reflexivity.
-      intros x y x_eq_y; split; symmetry; apply x_eq_y.
-    intros x y z x_eq_y y_eq_z; split.
-      transitivity (y.(State.index)).
-        apply x_eq_y.
-      apply y_eq_z.
-    transitivity (y.(State.owner_to_indices)).
-      apply x_eq_y.
-    apply y_eq_z.
-  Qed.
-
-  Instance Morphism_new :
-    Proper (Logic.eq ==> Map.Equal ==> Setoid.eq) State.new.
-  Proof.
-    intros index index' index_eq_index'
-      positions positions' positions_eq_positions'; split.
-      now rewrite index_eq_index'.
-    simpl.
-    now rewrite positions_eq_positions'.
-  Qed.
-
-  Instance Morphism_index :
-    Proper (Setoid.eq ==> Logic.eq) State.index.
-  Proof.
-    intros s s' s_eq_s'.
-    apply s_eq_s'.
-  Qed.
-
-  Instance Morphism_owner_to_indices :
-    Proper (Setoid.eq ==> Map.Equal) State.owner_to_indices.
-  Proof.
-    intros s s' s_eq_s'.
-    apply s_eq_s'.
-  Qed.
 
   Unset Program Cases.
   #[program]

--- a/Assigned/Positions.v
+++ b/Assigned/Positions.v
@@ -517,9 +517,9 @@ Module Make (Key Owner : DecidableTypeBoth) (Map : FMapInterface.WSfun Owner).
     (generate_body cards State.initial_state).(State.owner_to_indices).
 
   #[local]
-  Hint Resolve Algebraic.to_Relational_Theory : typeclass_instances.
+  Existing Instance Algebraic.to_Relational_Theory.
   #[local]
-  Hint Resolve Algebraic.to_Relational_Path_Theory : typeclass_instances.
+  Existing Instance Algebraic.to_Relational_Path_Theory.
 
   Lemma generate_spec :
     forall


### PR DESCRIPTION
From now on, we will interpret all algorithms as a generalization of a labelled transition system and use the framework to eliminate boilerplate proofs and data types.